### PR TITLE
feat: Get test job compatible with docker-compose

### DIFF
--- a/sources/index.yml
+++ b/sources/index.yml
@@ -743,24 +743,33 @@ jobs:
         type: string
         description: The variant to test
         default: ""
+      setup-steps:
+        type: steps
+        default: []
+      error-if-missing:
+        type: boolean
+        default: true
+      make-target:
+        type: string
+        default: "test"
     executor: << parameters.executor >>
     steps:
       - get-workspace
+      - steps: << parameters.setup-steps >>
       - run:
           name: Running tests
           command: |
-            if which make > /dev/null && [[ -e Makefile ]]; then
-              make test<<# parameters.variant >>-<</ parameters.variant >><< parameters.variant >>
-              exit 0
+            if which make > /dev/null && [[ -e Makefile ]] && make -n <<parameters.make-target>>; then
+              make <<parameters.make-target>>
+            else
+              if <<parameters.error-if-missing>>; then
+                echo "Unable to find a command runner"
+                exit 1
+              else
+                echo "No makefile with <<parameters.make-target>> target found. Assuming there's no tests to run"
+                exit 0
+              fi
             fi
-
-            if which npm > /dev/null && [[ -e package.json ]]; then
-              npm run test<<# parameters.variant >>-<</ parameters.variant >><< parameters.variant >>
-              exit 0
-            fi
-
-            echo "Unable to find a command runner"
-            exit 1
       - put-test-results:
           path: ./test-results
       - store_artifacts:


### PR DESCRIPTION
The existing test job seems to be used only here: https://github.com/ShaperTools/workspaces/blob/71690ce066ccdfd9478c13fd8d0768872cd3931e/.circleci/config.yml#L71. I added parameters to make it compatible with how I plan to use it in the services circle ci config, while keeping it backwards compatible with the usage in the workspaces repo.

This new job is used here: https://github.com/ShaperTools/infrastructure/pull/642

I also don't know how to release a new version of this. Github releases doesn't look correct since we use version 0.0.3 in the infrastructure repo, and the tagged releases are way higher than that (like 1.x.x). I'm also skeptical of the readme instructions since they look like a copy-paste from another repo / template.