### PR TITLE
fix: Fix debian versioning issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,12 @@ orbs:
 workflows:
   main:
     jobs:
-      - general/install-dependencies-npm
+      - general/install-dependencies-npm:
+          setup-steps:
+            - run:
+                name: Fix apt-get
+                command: |
+                  sudo apt-get update --allow-releaseinfo-change
       - general/lint-commit:
           requires:
             - general/install-dependencies-npm

--- a/sources/index.yml
+++ b/sources/index.yml
@@ -328,7 +328,7 @@ commands:
 
                 echo "Installing Node.js"
                 curl -sL https://deb.nodesource.com/setup_12.x | sudo bash -
-                sudo apt-get install -y nodejs
+                sudo apt-get update --allow-releaseinfo-change && sudo apt-get install -y nodejs
                 echo ""
 
                 npm ci
@@ -339,7 +339,7 @@ commands:
 
               echo "Installing Node.js"
               curl -sL https://deb.nodesource.com/setup_12.x | sudo bash -
-              sudo apt-get install -y nodejs
+              sudo apt-get update --allow-releaseinfo-change && sudo apt-get install -y nodejs
               echo ""
 
               npm install

--- a/sources/index.yml
+++ b/sources/index.yml
@@ -181,7 +181,7 @@ commands:
           name: Logging in to ECR
           command: |
             if ! which aws > /dev/null; then
-              sudo apt-get update && sudo apt-get install -y python3-pip
+              sudo apt-get update --allow-releaseinfo-change && sudo apt-get install -y python3-pip
               sudo pip3 install awscli
             fi
 
@@ -544,7 +544,7 @@ commands:
           name: Getting authentication token
           command: |
             if ! which aws > /dev/null; then
-              sudo apt-get update && sudo apt-get install -y python3-pip
+              sudo apt-get update --allow-releaseinfo-change && sudo apt-get install -y python3-pip
               sudo pip3 install awscli
             fi
 


### PR DESCRIPTION
`sudo apt-get update` was resulting in

```
Get:1 http://deb.debian.org/debian buster InRelease [122 kB]
Get:2 http://security.debian.org/debian-security buster/updates InRelease [65.4 kB]
Get:3 http://deb.debian.org/debian buster-updates InRelease [51.9 kB]
Reading package lists... Done      
E: Repository 'http://security.debian.org/debian-security buster/updates InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
N: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Version' value from '10.2' to '10.10'
E: Repository 'http://deb.debian.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
E: Repository 'http://deb.debian.org/debian buster-updates InRelease' changed its 'Suite' value from 'stable-updates' to 'oldstable-updates'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
```

This gets around that for now, just so we can build images again.