### PR TITLE
chore: Allow passing a backend-config file to terraform plan/apply

### DIFF
--- a/sources/index.yml
+++ b/sources/index.yml
@@ -1104,6 +1104,10 @@ jobs:
       lock-timeout:
         type: string
         default: "0s"
+      backend-config:
+        type: string
+        description: "passed to terraform plan -backend-config option"
+        default: ""
     executor:
       name: tfenv
     steps:
@@ -1113,7 +1117,15 @@ jobs:
       - steps: << parameters.setup-steps >>
       - run:
           name: Initializing Terraform
-          command: cd << parameters.directory >> && terraform init -input=false
+          command: |
+            cd << parameters.directory >>
+
+            backend_config=""
+            if [ "<< parameters.backend-config >>" ]; then
+              backend_config=" -backend-config=<< parameters.backend-config >>"
+            fi
+
+            terraform init -input=false $backend_config
       - select-or-create-workspace:
           directory: << parameters.directory >>
           workspace-name: << parameters.workspace >>
@@ -1187,6 +1199,10 @@ jobs:
       lock-timeout:
         type: string
         default: "0s"
+      backend-config:
+        type: string
+        description: "passed to terraform plan -backend-config option"
+        default: ""
     executor:
       name: tfenv
     steps:
@@ -1196,7 +1212,15 @@ jobs:
       - steps: << parameters.setup-steps >>
       - run:
           name: Initializing Terraform
-          command: cd << parameters.directory >> && terraform init -input=false
+          command: |
+            cd << parameters.directory >>
+
+            backend_config=""
+            if [ "<< parameters.backend-config >>" ]; then
+              backend_config=" -backend-config=<< parameters.backend-config >>"
+            fi
+
+            terraform init -input=false $backend_config
       - select-or-create-workspace:
           directory: << parameters.directory >>
           workspace-name: << parameters.workspace >>


### PR DESCRIPTION
This allows us to have a single terraform configuration for a service's infrastructure but pass in a dynamic backend configuration per environment. An example can be found in the [emails](https://github.com/ShaperTools/emails/blob/master/infrastructure/README.md) service.

I default the `backend-config` to an empty string in an attempt to make this backward compatible for all current users of this orb.