### PR TITLE
chore: Upgrade CI to use shapertools/general@0.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 orbs:
   circleci-cli: circleci/circleci-cli@0.1.8
   orbs: circleci/orb-tools@10.0.0
-  general: shapertools/general@dev:chore-update-gh-key
+  general: shapertools/general@0.5.0
 
 workflows:
   main:


### PR DESCRIPTION
Our [dev:chore-update-gh-key orb expired](https://app.circleci.com/pipelines/github/ShaperTools/configuration-ci-general) (see the failing job). We should probably be using a permanently published version for this anyway.

![image](https://github.com/ShaperTools/configuration-ci-general/assets/14257134/9b89fb4d-c461-4239-b603-98883cd6deda)
