### PR TITLE
fix: Setting remote docker version to default

### DIFF
--- a/sources/index.yml
+++ b/sources/index.yml
@@ -1325,7 +1325,7 @@ jobs:
         default: false
       docker-version:
         type: string
-        default: 20.10.7
+        default: default
       executor:
         type: executor
         default: buildpack-deps


### PR DESCRIPTION
Updating our remote docker version to `default` as recommended [here](https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176). 

Once this merges in we'll need to update the orb version referenced in individual repos. I imagine most pipelines will accept this change without issues but we may need to drop back to `docker23` on the rare chance that our pipelines aren't compatible with the default version. 

**Side Note:** Somehow version 0.6.0 has been published to the circleci orb repo manually but not checked in to source control. This should automatically publish 0.5.7, but we do have a higher version floating around out there.