### PR TITLE
Remove trailing `.` from parameter use in `configure-aws-profile` command

### DIFF
--- a/sources/index.yml
+++ b/sources/index.yml
@@ -201,7 +201,7 @@ commands:
             [<< parameters.profile-name >>]
             source_profile = << parameters.profile-name >>-credentials
             role_arn = ${<< parameters.aws-role-variable-name >>}
-            region = << parameters.region. >>
+            region = << parameters.region >>
 
             EOF
 


### PR DESCRIPTION
CircleCI config does not permit trailing `.` characters when referring to parameters.

While config using this orb is not currently rejected there are no guarantees that this will always be the case.

Changes:
* Correct the reference to `parameters.region` in the `configure-aws-profile` command.