### PR TITLE
fix: stop execution after halting during check-isolated-deployment-label

### DIFF
--- a/sources/index.yml
+++ b/sources/index.yml
@@ -38,6 +38,7 @@ commands:
             if [[ -z "${CIRCLE_PULL_REQUEST##*/}" ]]; then
               echo "Job is not running for a pull request. Halting the job."
               circleci-agent step halt
+              exit 0;
             fi
 
             PR_NUMBER=$(echo $CIRCLE_PULL_REQUEST | sed 's/.*\/pull\/\([0-9]*\)/\1/')


### PR DESCRIPTION
After halting, we should exit the step to avoid failures like this: https://app.circleci.com/pipelines/github/ShaperTools/Workspaces/828/workflows/3d2425b7-869b-4645-9f9c-2fec6f9b572f/jobs/5654