### PR TITLE
fix: Switch away from deprecated images

### DIFF
--- a/sources/index.yml
+++ b/sources/index.yml
@@ -10,7 +10,7 @@ orbs:
 executors:
   node:
     docker:
-      - image: cimg/node:12.22
+      - image: cimg/node:lts
         user: circleci
     resource_class: medium+
   buildpack-deps:

--- a/sources/index.yml
+++ b/sources/index.yml
@@ -10,12 +10,12 @@ orbs:
 executors:
   node:
     docker:
-      - image: circleci/node:12.22-buster
+      - image: cimg/node:12.22
         user: circleci
     resource_class: medium+
   buildpack-deps:
     docker:
-      - image: circleci/buildpack-deps:buster
+      - image: cimg/base:current-22.04
         user: circleci
   terraform:
     parameters:


### PR DESCRIPTION
I got a notification about a deprecated docker image brownout, along with [warnings](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) that we're using deprecated images.

No idea if this is affecting my CircleCI runs that are failing weirdly (it can't install node `v18.8.0` all of a sudden?), it's worth a shot and the images are going away at the end of this month anyway.