### PR TITLE
fix: Pin tfswitch to v1.4.4

### DIFF
--- a/sources/index.yml
+++ b/sources/index.yml
@@ -493,7 +493,7 @@ commands:
           name: Installing required Terraform version
           command: |
             cd << parameters.directory >>
-            curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/refs/tags/v1.4.6/install.sh | sudo bash
+            curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/master/install.sh | sudo bash -s -- 1.4.4
             [[ -f versions.tf ]] && filename="versions.tf" || filename="main.tf"
             desiredTerraformVersion=$(cat ${filename} | grep --extended-regexp '^\s*required_version\s*=\s*"\s*(=|>=)?\s*[0-9]+\.[0-9]+\.[0-9]+\s*"\s*$' | head | sed -E 's/^.*([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')
             tfswitch "${desiredTerraformVersion}"


### PR DESCRIPTION
Switching terraform version in CI started failing:

https://app.circleci.com/pipelines/github/ShaperTools/infrastructure/6922/workflows/52fd8109-8a29-4800-80f2-b896575e1c8f/jobs/373031/parallel-runs/0/steps/0-102

Due to:
https://github.com/warrensbox/terraform-switcher/issues/722


